### PR TITLE
Make temp login more robust

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -6,15 +6,7 @@ import {Provider} from 'react-redux';
 import {Router} from 'react-router-dom';
 import {ContameRouter} from './routing/ContameRouter';
 import {createBrowserHistory} from 'history';
-import {signIn} from './services/authentication';
 import store from './redux/store';
-import {login} from './redux/auth';
-
-// Tmp hack to handle auth without a login screen
-(async () => {
-  const loginInfo = await signIn();
-  store.dispatch(login(loginInfo.data.token));
-})();
 
 ReactDOM.render(
   <React.StrictMode>

--- a/src/redux/auth.js
+++ b/src/redux/auth.js
@@ -8,7 +8,7 @@ export const loginStatus = {
 
 const initialAuth = {
   status: loginStatus.NOT_LOGGED,
-  resources: null,
+  resources: new Resources(new HttpClient(null)),
 };
 
 const LOG_IN = 'LOG_IN';

--- a/src/services/ContameHttpClient.js
+++ b/src/services/ContameHttpClient.js
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import {signIn} from './authentication';
 
 export class HttpClient {
   constructor(token) {
@@ -10,6 +11,11 @@ export class HttpClient {
   }
 
   async request(url, method, data, headers) {
+    // Hack!!
+    if (this.token === null) {
+      const loginInfo = await signIn();
+      this.token = loginInfo.data.token;
+    }
     headers = headers || {};
     headers = {...headers, Authorization: `Bearer ${this.token}`};
     return await axios.request({url, method, data, headers});

--- a/src/services/Resources.js
+++ b/src/services/Resources.js
@@ -1,4 +1,4 @@
-import {useEffect, useState} from 'react';
+import {useCallback, useEffect, useState} from 'react';
 
 const BACKEND_URL = process.env.REACT_APP_BACKEND_URL;
 
@@ -21,12 +21,13 @@ export class Resources {
 }
 
 export const useGetResource = (fetchResource) => {
+  const callback = useCallback(fetchResource, []);
   const [data, setData] = useState(null);
   useEffect(() => {
     (async () => {
-      const resource = await fetchResource();
-      setData(resource);
+      const resource = await callback();
+      setData(() => resource);
     })();
-  }, [fetchResource]);
+  }, [callback]);
   return data;
 };


### PR DESCRIPTION
Paso a una estructura más básica:

Usamos siempre la misma instancia de HTTPClient
Ante cada request:

Si el client tiene token -> hace request
Si no existe el token -> el client hace login con credenciales temporales, guarda el token, y luego hace el request
También soluciona un loop infinito de requests en las tablas

